### PR TITLE
Support private entry as randomness security

### DIFF
--- a/src/core/__tests__/useABI.test.ts
+++ b/src/core/__tests__/useABI.test.ts
@@ -111,7 +111,7 @@ describe('useABI', () => {
       account,
       isSimulation: true,
     });
-    
+
     expect(result?.hash).toBeDefined();
     expect((result as any).payload).toMatchInlineSnapshot(`
 {
@@ -143,6 +143,15 @@ const TEST_ABI = {
       params: ['address', 'address'],
       return: [],
     },
+    {
+      name: 'pick_a_random_number',
+      visibility: 'private',
+      is_entry: true,
+      is_view: false,
+      generic_type_params: [],
+      params: [],
+      return: [],
+    }
   ],
   structs: [],
 } as const;

--- a/src/types/abi.ts
+++ b/src/types/abi.ts
@@ -12,7 +12,7 @@ export interface ABIRoot {
 
 export interface ABIFunction {
   name: string;
-  visibility: 'friend' | 'public';
+  visibility: 'friend' | 'public' | 'private';
   is_entry: boolean;
   is_view: boolean;
   generic_type_params: readonly ABIFunctionGenericTypeParam[];


### PR DESCRIPTION
Randomness APIs are enabled on devnet and testnet, and landing soon on mainnet. As [security considerations](https://aptos.dev/en/build/smart-contracts/randomness#security-considerations), requiring functions using randomness to be **private** to prevent test and abort attacks.

`ABIFunction` currently only supports `visibility: 'friend' | 'public'` so ABIs such as Aptogotchi Random Mint ([src](https://github.com/aptos-labs/aptogotchi-random-mint) and [ABI](https://fullnode.testnet.aptoslabs.com/v1/accounts/0x5211945b33c28c975544f65d361c3739a0244eb6779920128d72e7f70c088069/module/main)) will got type checking error.

```json
{
    "name": "create_aptogotchi",
    "visibility": "private",
    "is_entry": true,
    "is_view": false,
    "generic_type_params": [],
    "params": [
        "&signer"
    ],
    "return": []
}
```

I would like to introduce visibility `'private'` as well. Let me know if need more tests or any consideration. Thank you for this DX project!