### PR TITLE
Feat/Object From Struct String

### DIFF
--- a/src/abi/fungible_asset.ts
+++ b/src/abi/fungible_asset.ts
@@ -1,0 +1,1036 @@
+export const FUNGIBLE_ASSET = {
+  address: '0x1',
+  name: 'fungible_asset',
+  friends: [
+    '0x1::aptos_account',
+    '0x1::coin',
+    '0x1::dispatchable_fungible_asset',
+    '0x1::governed_gas_pool',
+    '0x1::primary_fungible_store',
+  ],
+  exposed_functions: [
+    {
+      name: 'add_fungibility',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: [
+        '&0x1::object::ConstructorRef',
+        '0x1::option::Option<u128>',
+        '0x1::string::String',
+        '0x1::string::String',
+        'u8',
+        '0x1::string::String',
+        '0x1::string::String',
+      ],
+      return: ['0x1::object::Object<0x1::fungible_asset::Metadata>'],
+    },
+    {
+      name: 'address_burn_from',
+      visibility: 'friend',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::fungible_asset::BurnRef', 'address', 'u64'],
+      return: [],
+    },
+    {
+      name: 'amount',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::fungible_asset::FungibleAsset'],
+      return: ['u64'],
+    },
+    {
+      name: 'asset_metadata',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::fungible_asset::FungibleAsset'],
+      return: ['0x1::object::Object<0x1::fungible_asset::Metadata>'],
+    },
+    {
+      name: 'balance',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['u64'],
+    },
+    {
+      name: 'burn',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: [
+        '&0x1::fungible_asset::BurnRef',
+        '0x1::fungible_asset::FungibleAsset',
+      ],
+      return: [],
+    },
+    {
+      name: 'burn_from',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: [
+        '&0x1::fungible_asset::BurnRef',
+        '0x1::object::Object<T0>',
+        'u64',
+      ],
+      return: [],
+    },
+    {
+      name: 'burn_internal',
+      visibility: 'friend',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['0x1::fungible_asset::FungibleAsset'],
+      return: ['u64'],
+    },
+    {
+      name: 'burn_ref_metadata',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::fungible_asset::BurnRef'],
+      return: ['0x1::object::Object<0x1::fungible_asset::Metadata>'],
+    },
+    {
+      name: 'create_store',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['&0x1::object::ConstructorRef', '0x1::object::Object<T0>'],
+      return: ['0x1::object::Object<0x1::fungible_asset::FungibleStore>'],
+    },
+    {
+      name: 'decimals',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['u8'],
+    },
+    {
+      name: 'deposit',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>', '0x1::fungible_asset::FungibleAsset'],
+      return: [],
+    },
+    {
+      name: 'deposit_dispatch_function',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::option::Option<0x1::function_info::FunctionInfo>'],
+    },
+    {
+      name: 'deposit_internal',
+      visibility: 'friend',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['address', '0x1::fungible_asset::FungibleAsset'],
+      return: [],
+    },
+    {
+      name: 'deposit_sanity_check',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>', 'bool'],
+      return: [],
+    },
+    {
+      name: 'deposit_with_ref',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: [
+        '&0x1::fungible_asset::TransferRef',
+        '0x1::object::Object<T0>',
+        '0x1::fungible_asset::FungibleAsset',
+      ],
+      return: [],
+    },
+    {
+      name: 'derived_balance_dispatch_function',
+      visibility: 'friend',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::option::Option<0x1::function_info::FunctionInfo>'],
+    },
+    {
+      name: 'destroy_zero',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['0x1::fungible_asset::FungibleAsset'],
+      return: [],
+    },
+    {
+      name: 'extract',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&mut 0x1::fungible_asset::FungibleAsset', 'u64'],
+      return: ['0x1::fungible_asset::FungibleAsset'],
+    },
+    {
+      name: 'generate_burn_ref',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::object::ConstructorRef'],
+      return: ['0x1::fungible_asset::BurnRef'],
+    },
+    {
+      name: 'generate_mint_ref',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::object::ConstructorRef'],
+      return: ['0x1::fungible_asset::MintRef'],
+    },
+    {
+      name: 'generate_mutate_metadata_ref',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::object::ConstructorRef'],
+      return: ['0x1::fungible_asset::MutateMetadataRef'],
+    },
+    {
+      name: 'generate_transfer_ref',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::object::ConstructorRef'],
+      return: ['0x1::fungible_asset::TransferRef'],
+    },
+    {
+      name: 'icon_uri',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::string::String'],
+    },
+    {
+      name: 'is_address_balance_at_least',
+      visibility: 'friend',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['address', 'u64'],
+      return: ['bool'],
+    },
+    {
+      name: 'is_balance_at_least',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>', 'u64'],
+      return: ['bool'],
+    },
+    {
+      name: 'is_frozen',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['bool'],
+    },
+    {
+      name: 'is_store_dispatchable',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['bool'],
+    },
+    {
+      name: 'is_untransferable',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['bool'],
+    },
+    {
+      name: 'maximum',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::option::Option<u128>'],
+    },
+    {
+      name: 'merge',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: [
+        '&mut 0x1::fungible_asset::FungibleAsset',
+        '0x1::fungible_asset::FungibleAsset',
+      ],
+      return: [],
+    },
+    {
+      name: 'metadata',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::fungible_asset::Metadata'],
+    },
+    {
+      name: 'metadata_from_asset',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::fungible_asset::FungibleAsset'],
+      return: ['0x1::object::Object<0x1::fungible_asset::Metadata>'],
+    },
+    {
+      name: 'mint',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::fungible_asset::MintRef', 'u64'],
+      return: ['0x1::fungible_asset::FungibleAsset'],
+    },
+    {
+      name: 'mint_internal',
+      visibility: 'friend',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['0x1::object::Object<0x1::fungible_asset::Metadata>', 'u64'],
+      return: ['0x1::fungible_asset::FungibleAsset'],
+    },
+    {
+      name: 'mint_ref_metadata',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::fungible_asset::MintRef'],
+      return: ['0x1::object::Object<0x1::fungible_asset::Metadata>'],
+    },
+    {
+      name: 'mint_to',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: [
+        '&0x1::fungible_asset::MintRef',
+        '0x1::object::Object<T0>',
+        'u64',
+      ],
+      return: [],
+    },
+    {
+      name: 'mutate_metadata',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: [
+        '&0x1::fungible_asset::MutateMetadataRef',
+        '0x1::option::Option<0x1::string::String>',
+        '0x1::option::Option<0x1::string::String>',
+        '0x1::option::Option<u8>',
+        '0x1::option::Option<0x1::string::String>',
+        '0x1::option::Option<0x1::string::String>',
+      ],
+      return: [],
+    },
+    {
+      name: 'name',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::string::String'],
+    },
+    {
+      name: 'object_from_metadata_ref',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::fungible_asset::MutateMetadataRef'],
+      return: ['0x1::object::Object<0x1::fungible_asset::Metadata>'],
+    },
+    {
+      name: 'project_uri',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::string::String'],
+    },
+    {
+      name: 'register_dispatch_functions',
+      visibility: 'friend',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: [
+        '&0x1::object::ConstructorRef',
+        '0x1::option::Option<0x1::function_info::FunctionInfo>',
+        '0x1::option::Option<0x1::function_info::FunctionInfo>',
+        '0x1::option::Option<0x1::function_info::FunctionInfo>',
+      ],
+      return: [],
+    },
+    {
+      name: 'remove_store',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::object::DeleteRef'],
+      return: [],
+    },
+    {
+      name: 'set_frozen_flag',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: [
+        '&0x1::fungible_asset::TransferRef',
+        '0x1::object::Object<T0>',
+        'bool',
+      ],
+      return: [],
+    },
+    {
+      name: 'set_frozen_flag_internal',
+      visibility: 'friend',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>', 'bool'],
+      return: [],
+    },
+    {
+      name: 'set_untransferable',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::object::ConstructorRef'],
+      return: [],
+    },
+    {
+      name: 'store_exists',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [],
+      params: ['address'],
+      return: ['bool'],
+    },
+    {
+      name: 'store_metadata',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::object::Object<0x1::fungible_asset::Metadata>'],
+    },
+    {
+      name: 'supply',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::option::Option<u128>'],
+    },
+    {
+      name: 'symbol',
+      visibility: 'public',
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::string::String'],
+    },
+    {
+      name: 'transfer',
+      visibility: 'public',
+      is_entry: true,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: [
+        '&signer',
+        '0x1::object::Object<T0>',
+        '0x1::object::Object<T0>',
+        'u64',
+      ],
+      return: [],
+    },
+    {
+      name: 'transfer_ref_metadata',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::fungible_asset::TransferRef'],
+      return: ['0x1::object::Object<0x1::fungible_asset::Metadata>'],
+    },
+    {
+      name: 'transfer_with_ref',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: [
+        '&0x1::fungible_asset::TransferRef',
+        '0x1::object::Object<T0>',
+        '0x1::object::Object<T0>',
+        'u64',
+      ],
+      return: [],
+    },
+    {
+      name: 'upgrade_store_to_concurrent',
+      visibility: 'public',
+      is_entry: true,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['&signer', '0x1::object::Object<T0>'],
+      return: [],
+    },
+    {
+      name: 'upgrade_to_concurrent',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['&0x1::object::ExtendRef'],
+      return: [],
+    },
+    {
+      name: 'withdraw',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['&signer', '0x1::object::Object<T0>', 'u64'],
+      return: ['0x1::fungible_asset::FungibleAsset'],
+    },
+    {
+      name: 'withdraw_dispatch_function',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::option::Option<0x1::function_info::FunctionInfo>'],
+    },
+    {
+      name: 'withdraw_internal',
+      visibility: 'friend',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [],
+      params: ['address', 'u64'],
+      return: ['0x1::fungible_asset::FungibleAsset'],
+    },
+    {
+      name: 'withdraw_sanity_check',
+      visibility: 'friend',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['&signer', '0x1::object::Object<T0>', 'bool'],
+      return: [],
+    },
+    {
+      name: 'withdraw_with_ref',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: [
+        '&0x1::fungible_asset::TransferRef',
+        '0x1::object::Object<T0>',
+        'u64',
+      ],
+      return: ['0x1::fungible_asset::FungibleAsset'],
+    },
+    {
+      name: 'zero',
+      visibility: 'public',
+      is_entry: false,
+      is_view: false,
+      generic_type_params: [
+        {
+          constraints: ['key'],
+        },
+      ],
+      params: ['0x1::object::Object<T0>'],
+      return: ['0x1::fungible_asset::FungibleAsset'],
+    },
+  ],
+  structs: [
+    {
+      name: 'BurnRef',
+      is_native: false,
+      abilities: ['drop', 'store'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'metadata',
+          type: '0x1::object::Object<0x1::fungible_asset::Metadata>',
+        },
+      ],
+    },
+    {
+      name: 'ConcurrentFungibleBalance',
+      is_native: false,
+      abilities: ['key'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'balance',
+          type: '0x1::aggregator_v2::Aggregator<u64>',
+        },
+      ],
+    },
+    {
+      name: 'ConcurrentSupply',
+      is_native: false,
+      abilities: ['key'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'current',
+          type: '0x1::aggregator_v2::Aggregator<u128>',
+        },
+      ],
+    },
+    {
+      name: 'Deposit',
+      is_native: false,
+      abilities: ['drop', 'store'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'store',
+          type: 'address',
+        },
+        {
+          name: 'amount',
+          type: 'u64',
+        },
+      ],
+    },
+    {
+      name: 'DepositEvent',
+      is_native: false,
+      abilities: ['drop', 'store'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'amount',
+          type: 'u64',
+        },
+      ],
+    },
+    {
+      name: 'DispatchFunctionStore',
+      is_native: false,
+      abilities: ['key'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'withdraw_function',
+          type: '0x1::option::Option<0x1::function_info::FunctionInfo>',
+        },
+        {
+          name: 'deposit_function',
+          type: '0x1::option::Option<0x1::function_info::FunctionInfo>',
+        },
+        {
+          name: 'derived_balance_function',
+          type: '0x1::option::Option<0x1::function_info::FunctionInfo>',
+        },
+      ],
+    },
+    {
+      name: 'Frozen',
+      is_native: false,
+      abilities: ['drop', 'store'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'store',
+          type: 'address',
+        },
+        {
+          name: 'frozen',
+          type: 'bool',
+        },
+      ],
+    },
+    {
+      name: 'FrozenEvent',
+      is_native: false,
+      abilities: ['drop', 'store'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'frozen',
+          type: 'bool',
+        },
+      ],
+    },
+    {
+      name: 'FungibleAsset',
+      is_native: false,
+      abilities: [],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'metadata',
+          type: '0x1::object::Object<0x1::fungible_asset::Metadata>',
+        },
+        {
+          name: 'amount',
+          type: 'u64',
+        },
+      ],
+    },
+    {
+      name: 'FungibleAssetEvents',
+      is_native: false,
+      abilities: ['key'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'deposit_events',
+          type: '0x1::event::EventHandle<0x1::fungible_asset::DepositEvent>',
+        },
+        {
+          name: 'withdraw_events',
+          type: '0x1::event::EventHandle<0x1::fungible_asset::WithdrawEvent>',
+        },
+        {
+          name: 'frozen_events',
+          type: '0x1::event::EventHandle<0x1::fungible_asset::FrozenEvent>',
+        },
+      ],
+    },
+    {
+      name: 'FungibleStore',
+      is_native: false,
+      abilities: ['key'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'metadata',
+          type: '0x1::object::Object<0x1::fungible_asset::Metadata>',
+        },
+        {
+          name: 'balance',
+          type: 'u64',
+        },
+        {
+          name: 'frozen',
+          type: 'bool',
+        },
+      ],
+    },
+    {
+      name: 'Metadata',
+      is_native: false,
+      abilities: ['copy', 'drop', 'key'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'name',
+          type: '0x1::string::String',
+        },
+        {
+          name: 'symbol',
+          type: '0x1::string::String',
+        },
+        {
+          name: 'decimals',
+          type: 'u8',
+        },
+        {
+          name: 'icon_uri',
+          type: '0x1::string::String',
+        },
+        {
+          name: 'project_uri',
+          type: '0x1::string::String',
+        },
+      ],
+    },
+    {
+      name: 'MintRef',
+      is_native: false,
+      abilities: ['drop', 'store'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'metadata',
+          type: '0x1::object::Object<0x1::fungible_asset::Metadata>',
+        },
+      ],
+    },
+    {
+      name: 'MutateMetadataRef',
+      is_native: false,
+      abilities: ['drop', 'store'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'metadata',
+          type: '0x1::object::Object<0x1::fungible_asset::Metadata>',
+        },
+      ],
+    },
+    {
+      name: 'Supply',
+      is_native: false,
+      abilities: ['key'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'current',
+          type: 'u128',
+        },
+        {
+          name: 'maximum',
+          type: '0x1::option::Option<u128>',
+        },
+      ],
+    },
+    {
+      name: 'TransferRef',
+      is_native: false,
+      abilities: ['drop', 'store'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'metadata',
+          type: '0x1::object::Object<0x1::fungible_asset::Metadata>',
+        },
+      ],
+    },
+    {
+      name: 'Untransferable',
+      is_native: false,
+      abilities: ['key'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'dummy_field',
+          type: 'bool',
+        },
+      ],
+    },
+    {
+      name: 'Withdraw',
+      is_native: false,
+      abilities: ['drop', 'store'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'store',
+          type: 'address',
+        },
+        {
+          name: 'amount',
+          type: 'u64',
+        },
+      ],
+    },
+    {
+      name: 'WithdrawEvent',
+      is_native: false,
+      abilities: ['drop', 'store'],
+      generic_type_params: [],
+      fields: [
+        {
+          name: 'amount',
+          type: 'u64',
+        },
+      ],
+    },
+  ],
+} as const;

--- a/src/types/convertor/argsConvertor.ts
+++ b/src/types/convertor/argsConvertor.ts
@@ -3,8 +3,12 @@
  * for input arguments of view function or entry function.
  */
 
-import { AnyNumber, UnknownStruct } from '../common.js';
-import { MoveNonStructTypes, MovePrimitive } from '../moveTypes.js';
+import { UnknownStruct } from '../common.js';
+import {
+  MoveNonStructTypes,
+  MovePrimitive,
+  MovePrimitivesMap,
+} from '../moveTypes.js';
 
 /**
  * Convert an array of input arguments type.
@@ -27,25 +31,7 @@ type ConvertArgType<TMoveType extends string> =
       UnknownStruct<TMoveType>;
 
 type ConvertPrimitiveArgType<TMoveType extends MovePrimitive> =
-  TMoveType extends 'bool'
-    ? boolean
-    : TMoveType extends 'u8'
-      ? number
-      : TMoveType extends 'u16'
-        ? number
-        : TMoveType extends 'u32'
-          ? number
-          : TMoveType extends 'u64'
-            ? AnyNumber
-            : TMoveType extends 'u128'
-              ? AnyNumber
-              : TMoveType extends 'u256'
-                ? AnyNumber
-                : TMoveType extends 'address'
-                  ? `0x${string}`
-                  : TMoveType extends '0x1::string::String'
-                    ? string
-                    : never;
+  MovePrimitivesMap[TMoveType];
 
 type ConvertNonStructArgType<TMoveType extends MoveNonStructTypes> =
   TMoveType extends MovePrimitive

--- a/src/types/convertor/returnConvertor.ts
+++ b/src/types/convertor/returnConvertor.ts
@@ -3,59 +3,57 @@
  * for return value of view functions.
  */
 
+import { ABIRoot } from '../abi.js';
 import { UnknownStruct } from '../common.js';
 import { DefaultABITable } from '../defaultABITable.js';
-import { MoveNonStructTypes, MovePrimitive } from '../moveTypes.js';
+import {
+  ConvertedStruct,
+  ExtractStruct,
+  ExtractStructName,
+} from '../extractor/struct.js';
+import {
+  MoveNonStructTypes,
+  MovePrimitive,
+  MovePrimitivesMap,
+} from '../moveTypes.js';
 import { ConvertStructFieldOptionType } from './structConvertor.js';
 
 /**
  * Convert an array of return types.
  */
-export type ConvertReturns<T extends readonly string[]> = T extends readonly [
+export type ConvertReturns<
+  ABI extends ABIRoot,
+  T extends readonly string[],
+> = T extends readonly [
   infer TArg extends string,
   ...infer TRest extends string[],
 ]
-  ? [ConvertReturnType<TArg>, ...ConvertReturns<TRest>]
+  ? [ConvertReturnType<ABI, TArg>, ...ConvertReturns<ABIRoot, TRest>]
   : [];
 
 /**
  * Internal
  */
-type ConvertReturnType<TMoveType extends string> =
-  TMoveType extends MoveNonStructTypes
-    ? // it's a non-struct type
-      ConvertNonStructReturnType<TMoveType>
-    : // it's a struct type
-      UnknownStruct<TMoveType>;
+type ConvertReturnType<
+  ABI extends ABIRoot,
+  TMoveType extends string,
+> = TMoveType extends MoveNonStructTypes
+  ? // it's a non-struct type
+    ConvertNonStructReturnType<ABI, TMoveType>
+  : // Verify if struct is a valid string, example 0x1::object_name::StructName and infer only StructName to a new type for validation
+    TMoveType extends ExtractStructName<ABI, infer StructName>
+    ? ConvertedStruct<ABI, ExtractStruct<ABI, StructName>>
+    : UnknownStruct<TMoveType>;
 
-type ConvertPrimitiveReturnType<TMoveType extends MovePrimitive> =
-  TMoveType extends 'bool'
-    ? boolean
-    : TMoveType extends 'u8'
-      ? number
-      : TMoveType extends 'u16'
-        ? number
-        : TMoveType extends 'u32'
-          ? number
-          : TMoveType extends 'u64'
-            ? string
-            : TMoveType extends 'u128'
-              ? string
-              : TMoveType extends 'u256'
-                ? string
-                : TMoveType extends 'address'
-                  ? `0x${string}`
-                  : TMoveType extends '0x1::string::String'
-                    ? string
-                    : never;
-
-type ConvertNonStructReturnType<TMoveType extends MoveNonStructTypes> =
-  TMoveType extends MovePrimitive
-    ? ConvertPrimitiveReturnType<TMoveType>
-    : TMoveType extends `vector<${infer TInner}>`
-      ? ConvertReturnType<TInner>[]
-      : TMoveType extends `0x1::object::Object<${string}>`
-        ? { inner: `0x${string}` }
-        : TMoveType extends `0x1::option::Option<${infer TInner}>`
-          ? ConvertStructFieldOptionType<DefaultABITable, TInner>
-          : UnknownStruct<TMoveType>;
+type ConvertNonStructReturnType<
+  ABI extends ABIRoot,
+  TMoveType extends MoveNonStructTypes,
+> = TMoveType extends MovePrimitive
+  ? MovePrimitivesMap[TMoveType]
+  : TMoveType extends `vector<${infer TInner}>`
+    ? ConvertReturnType<ABI, TInner>[]
+    : TMoveType extends `0x1::object::Object<${string}>`
+      ? { inner: `0x${string}` }
+      : TMoveType extends `0x1::option::Option<${infer TInner}>`
+        ? ConvertStructFieldOptionType<DefaultABITable, TInner>
+        : UnknownStruct<TMoveType>;

--- a/src/types/convertor/structConvertor.ts
+++ b/src/types/convertor/structConvertor.ts
@@ -7,7 +7,11 @@ import {
   ExtractStructType,
   ResourceStructName,
 } from '../extractor/structExtractor.js';
-import { MoveNonStructTypes, MovePrimitive } from '../moveTypes.js';
+import {
+  MoveNonStructTypes,
+  MovePrimitive,
+  MovePrimitivesMap,
+} from '../moveTypes.js';
 
 // Convert a struct field Move type to a TypeScript type
 export type ConvertStructFieldType<
@@ -19,35 +23,12 @@ export type ConvertStructFieldType<
   : // it's a struct type
     ConvertStructFieldStructType<TABITable, TMoveType>;
 
-/**
- * Internal
- */
-type ConvertPrimitiveStructField<T extends MovePrimitive> = T extends 'bool'
-  ? boolean
-  : T extends 'u8'
-    ? number
-    : T extends 'u16'
-      ? number
-      : T extends 'u32'
-        ? number
-        : T extends 'u64'
-          ? string
-          : T extends 'u128'
-            ? string
-            : T extends 'u256'
-              ? string
-              : T extends 'address'
-                ? `0x${string}`
-                : T extends '0x1::string::String'
-                  ? string
-                  : never;
-
 // Convert a struct field non-struct Move type to a TypeScript type
 type ConvertStructFieldNonStructType<
   TABITable extends ABITable,
   TMoveType extends MoveNonStructTypes,
 > = TMoveType extends MovePrimitive
-  ? ConvertPrimitiveStructField<TMoveType>
+  ? MovePrimitivesMap[TMoveType]
   : TMoveType extends `vector<${infer TInner}>`
     ? ConvertStructFieldType<TABITable, TInner>[]
     : TMoveType extends `0x1::object::Object<${string}>`

--- a/src/types/extractor/functionExtractor.ts
+++ b/src/types/extractor/functionExtractor.ts
@@ -22,33 +22,33 @@ export type EntryFunctionName<T extends ABIRoot> = EntryFunction<T>['name'];
  * Extract the return type of a function from ABI with function name.
  */
 export type ExtractReturnType<
-  T extends ABIRoot,
-  TFuncName extends FunctionName<T>,
-> = ConvertReturns<ExtractMoveReturnType<T, TFuncName>>;
+  Abi extends ABIRoot,
+  TFuncName extends FunctionName<Abi>,
+> = ConvertReturns<Abi, ExtractMoveReturnType<Abi, TFuncName>>;
 
 /**
  * Extract the input arguments type of a function from ABI with function name.
  */
 export type ExtractArgsType<
-  T extends ABIRoot,
-  TFuncName extends FunctionName<T>,
-> = ConvertArgs<ExtractMoveArgsType<T, TFuncName>>;
+  Abi extends ABIRoot,
+  TFuncName extends FunctionName<Abi>,
+> = ConvertArgs<ExtractMoveArgsType<Abi, TFuncName>>;
 
 /**
  * Extract the input arguments type of a function from ABI with function name, but omit the signer.
  */
 export type ExtractArgsTypeOmitSigner<
-  T extends ABIRoot,
-  TFuncName extends FunctionName<T>,
-> = ConvertArgs<OmitSigner<ExtractMoveArgsType<T, TFuncName>>>;
+  Abi extends ABIRoot,
+  TFuncName extends FunctionName<Abi>,
+> = ConvertArgs<OmitSigner<ExtractMoveArgsType<Abi, TFuncName>>>;
 
 /**
  * Extract the input generic arguments type of a function from ABI with function name.
  */
 export type ExtractGenericArgsType<
-  T extends ABIRoot,
-  TFuncName extends FunctionName<T>,
-> = ConvertGenerics<ExtractMoveGenericParamsType<T, TFuncName>>;
+  Abi extends ABIRoot,
+  TFuncName extends FunctionName<Abi>,
+> = ConvertGenerics<ExtractMoveGenericParamsType<Abi, TFuncName>>;
 
 /**
  * Internal
@@ -66,21 +66,21 @@ type EntryFunction<T extends ABIRoot> = Extract<
 >;
 
 type ExtractFunction<
-  T extends ABIRoot,
-  TFuncName extends FunctionName<T>,
-> = Extract<Function<T>, { name: TFuncName }>;
+  Abi extends ABIRoot,
+  TFuncName extends FunctionName<Abi>,
+> = Extract<Function<Abi>, { name: TFuncName }>;
 
 type ExtractMoveReturnType<
-  T extends ABIRoot,
-  TFuncName extends FunctionName<T>,
-> = ExtractFunction<T, TFuncName>['return'];
+  Abi extends ABIRoot,
+  TFuncName extends FunctionName<Abi>,
+> = ExtractFunction<Abi, TFuncName>['return'];
 
 type ExtractMoveArgsType<
-  T extends ABIRoot,
-  TFuncName extends FunctionName<T>,
-> = ExtractFunction<T, TFuncName>['params'];
+  Abi extends ABIRoot,
+  TFuncName extends FunctionName<Abi>,
+> = ExtractFunction<Abi, TFuncName>['params'];
 
 type ExtractMoveGenericParamsType<
-  T extends ABIRoot,
-  TFuncName extends FunctionName<T>,
-> = ExtractFunction<T, TFuncName>['generic_type_params'];
+  Abi extends ABIRoot,
+  TFuncName extends FunctionName<Abi>,
+> = ExtractFunction<Abi, TFuncName>['generic_type_params'];

--- a/src/types/extractor/struct.ts
+++ b/src/types/extractor/struct.ts
@@ -1,0 +1,35 @@
+import { ABIRoot, ABIStruct } from '../abi.js';
+import { MovePrimitivesMap } from '../moveTypes.js';
+
+// =====================================================
+// DEFINED TYPES
+// =====================================================
+
+// ====================================================
+// STRUCTS
+// ====================================================
+
+export type ExtractStructName<
+  ABI extends ABIRoot,
+  FunctionName extends string,
+> =
+  | `0x1::object::Object<${ABI['address']}::${ABI['name']}::${FunctionName}>`
+  | `${ABI['address']}::${ABI['name']}::${FunctionName}`;
+
+// Extracts a raw Struct from the ABI structs array by its name.
+export type ExtractStruct<
+  Abi extends ABIRoot,
+  T extends Abi['structs'][number]['name'],
+> = Extract<Abi['structs'][number], { name: T }>;
+
+// Convert a raw Struct from abi to an object with its fields and parsed object types
+export type ConvertedStruct<ABI extends ABIRoot, T extends ABIStruct> = {
+  [K in T['fields'][number] as K['name']]: K['type'] extends keyof MovePrimitivesMap
+    ? MovePrimitivesMap[K['type']] // Non Struct Types
+    : K['type'] extends ExtractStructName<ABI, infer StructName>
+      ? StructName extends ABI['structs'][number]['name']
+        ? // Transformed 0x1::object::Object<0x1::coin::CustomStruct> to object.
+          ConvertedStruct<ABI, ExtractStruct<ABI, StructName>>
+        : never
+      : never;
+};

--- a/src/types/moveTypes.ts
+++ b/src/types/moveTypes.ts
@@ -2,22 +2,29 @@
  * Types from Move language
  */
 
+import { AnyNumber } from './common.js';
+
 export type MoveNonStructTypes =
   | MovePrimitive
   | MoveVector
   | MoveObject
   | MoveOption;
 
-export type MovePrimitive =
-  | 'bool'
-  | 'u8'
-  | 'u16'
-  | 'u32'
-  | 'u64'
-  | 'u128'
-  | 'u256'
-  | 'address'
-  | '0x1::string::String';
+export type MovePrimitivesMap = {
+  '0x1::string::String': string;
+  address: `0x${string}`;
+
+  // Numeric types
+  u8: number;
+  u16: number;
+  u32: number;
+  u64: AnyNumber;
+  u128: AnyNumber;
+  u256: AnyNumber;
+
+  bool: boolean;
+};
+export type MovePrimitive = keyof MovePrimitivesMap;
 
 export type MoveVector = `vector<${string}>`;
 


### PR DESCRIPTION
# This PR will

## Add a better handling for primitives conversion with object mapping 

Before:
```ts
type ConvertPrimitiveArgType<TMoveType extends MovePrimitive> =
  TMoveType extends 'bool'
    ? boolean
    : TMoveType extends 'u8'
      ? number
      : TMoveType extends 'u16'
        ? number
        : TMoveType extends 'u32'
          ? number
          : TMoveType extends 'u64'
            ? AnyNumber
            : TMoveType extends 'u128'
              ? AnyNumber
              : TMoveType extends 'u256'
                ? AnyNumber
                : TMoveType extends 'address'
                  ? `0x${string}`
                  : TMoveType extends '0x1::string::String'
                    ? string
                    : never;

... ? ConvertPrimitiveArgType<TMoveType>
```
Now 
```ts
import {  MovePrimitivesMap } from '../moveTypes.js';
... ? ConvertPrimitiveArgType[TMoveType]
```
This will ensure reusability and simplicity to the code, before 3 files for convertor was creating the same huge type 3 times for validating simple types

With this approach we can now just define a Map object with the respective type to a string or value:

```ts
export type MovePrimitivesMap = {
  '0x1::string::String': string;
  address: `0x${string}`;

  // Numeric types
  u8: number;
  u16: number;
  u32: number;
  u64: AnyNumber;
  u128: AnyNumber;
  u256: AnyNumber;

  bool: boolean;
};
```
This way we can avoid the the huge ternary verifications.

## Add a convertor for struct objects

![image](https://github.com/user-attachments/assets/e88a9d02-34ec-4b57-ab18-defadb916afb)

Using the fungible asset as example because I had to struggle a bit to support it with raw aptos package, aiming to provide full support for this in future with surf package.

