### PR TITLE
Chore/Better Types

### DIFF
--- a/src/core/__tests__/createEntryPayload.test.ts
+++ b/src/core/__tests__/createEntryPayload.test.ts
@@ -183,7 +183,9 @@ describe('createEntryPayload', () => {
       createEntryPayload(TEST_ABI, {
         function: 'vector_of_vector_as_input',
         functionArguments: [
+          // @ts-expect-error invalid vector<vector<u8>>
           [[], 1, 2, '3'],
+          // @ts-expect-error invalid vector<vector<address>>
           [[], 1, 2, '3'],
         ],
         typeArguments: [],

--- a/src/core/__tests__/createEntryPayload.test.ts
+++ b/src/core/__tests__/createEntryPayload.test.ts
@@ -183,9 +183,7 @@ describe('createEntryPayload', () => {
       createEntryPayload(TEST_ABI, {
         function: 'vector_of_vector_as_input',
         functionArguments: [
-          // @ts-expect-error invalid vector<vector<u8>>
           [[], 1, 2, '3'],
-          // @ts-expect-error invalid vector<vector<address>>
           [[], 1, 2, '3'],
         ],
         typeArguments: [],

--- a/src/types/convertor/argsConvertor.ts
+++ b/src/types/convertor/argsConvertor.ts
@@ -2,9 +2,13 @@
  * Convert Move type to TypeScript type,
  * for input arguments of view function or entry function.
  */
-
 import { AnyNumber, UnknownStruct } from '../common.js';
-import { MoveNonStructTypes, MovePrimitive } from '../moveTypes.js';
+import {
+  MoveObject,
+  MoveOption,
+  MovePrimitive,
+  MovePrimitiveMap,
+} from '../moveTypes.js';
 
 /**
  * Convert an array of input arguments type.
@@ -16,46 +20,11 @@ export type ConvertArgs<T extends readonly string[]> = T extends readonly [
   ? [ConvertArgType<TArg>, ...ConvertArgs<TRest>]
   : [];
 
-/**
- * Internal
- */
-type ConvertArgType<TMoveType extends string> =
-  TMoveType extends MoveNonStructTypes
-    ? // it's a non-struct type
-      ConvertNonStructArgType<TMoveType>
-    : // it's a struct type
-      UnknownStruct<TMoveType>;
-
-type ConvertPrimitiveArgType<TMoveType extends MovePrimitive> =
-  TMoveType extends 'bool'
-    ? boolean
-    : TMoveType extends 'u8'
-      ? number
-      : TMoveType extends 'u16'
-        ? number
-        : TMoveType extends 'u32'
-          ? number
-          : TMoveType extends 'u64'
-            ? AnyNumber
-            : TMoveType extends 'u128'
-              ? AnyNumber
-              : TMoveType extends 'u256'
-                ? AnyNumber
-                : TMoveType extends 'address'
-                  ? `0x${string}`
-                  : TMoveType extends '0x1::string::String'
-                    ? string
-                    : never;
-
-type ConvertNonStructArgType<TMoveType extends MoveNonStructTypes> =
-  TMoveType extends MovePrimitive
-    ? ConvertPrimitiveArgType<TMoveType>
-    : TMoveType extends `vector<u8>`
-      ? string | number[] | Uint8Array
-      : TMoveType extends `vector<${infer TInner}>`
-        ? ConvertArgType<TInner>[]
-        : TMoveType extends `0x1::object::Object<${string}>`
-          ? `0x${string}`
-          : TMoveType extends `0x1::option::Option<${infer TInner}>`
-            ? ConvertArgType<TInner> | undefined
-            : UnknownStruct<TMoveType>;
+// Internal
+type ConvertArgType<TMoveType extends string> = TMoveType extends MovePrimitive
+  ? MovePrimitiveMap<AnyNumber>[TMoveType]
+  : TMoveType extends MoveObject
+    ? `0x${string}`
+    : TMoveType extends MoveOption<infer TInner>
+      ? ConvertArgType<TInner> | undefined
+      : UnknownStruct<TMoveType>;

--- a/src/types/convertor/argsConvertor.ts
+++ b/src/types/convertor/argsConvertor.ts
@@ -8,6 +8,7 @@ import {
   MoveOption,
   MovePrimitive,
   MovePrimitiveMap,
+  MoveVector,
 } from '../moveTypes.js';
 
 /**
@@ -25,6 +26,8 @@ type ConvertArgType<TMoveType extends string> = TMoveType extends MovePrimitive
   ? MovePrimitiveMap<AnyNumber>[TMoveType]
   : TMoveType extends MoveObject
     ? `0x${string}`
-    : TMoveType extends MoveOption<infer TInner>
-      ? ConvertArgType<TInner> | undefined
-      : UnknownStruct<TMoveType>;
+    : TMoveType extends MoveVector<infer TInner>
+      ? ConvertArgType<TInner>[]
+      : TMoveType extends MoveOption<infer TInner>
+        ? ConvertArgType<TInner> | undefined
+        : UnknownStruct<TMoveType>;

--- a/src/types/convertor/returnConvertor.ts
+++ b/src/types/convertor/returnConvertor.ts
@@ -10,6 +10,7 @@ import {
   MoveOption,
   MovePrimitive,
   MovePrimitiveMap,
+  MoveVector,
 } from '../moveTypes.js';
 import { ConvertStructFieldOptionType } from './structConvertor.js';
 
@@ -29,8 +30,10 @@ export type ConvertReturns<T extends readonly string[]> = T extends readonly [
 type ConvertReturnType<TMoveType extends string> =
   TMoveType extends MovePrimitive
     ? MovePrimitiveMap<string>[TMoveType]
-    : TMoveType extends MoveObject
-      ? { inner: `0x${string}` }
-      : TMoveType extends MoveOption<infer TInner>
-        ? ConvertStructFieldOptionType<DefaultABITable, TInner>
-        : UnknownStruct<TMoveType>;
+    : TMoveType extends MoveVector<infer TInner>
+      ? ConvertReturnType<TInner>[]
+      : TMoveType extends MoveObject
+        ? { inner: `0x${string}` }
+        : TMoveType extends MoveOption<infer TInner>
+          ? ConvertStructFieldOptionType<DefaultABITable, TInner>
+          : UnknownStruct<TMoveType>;

--- a/src/types/convertor/returnConvertor.ts
+++ b/src/types/convertor/returnConvertor.ts
@@ -5,7 +5,12 @@
 
 import { UnknownStruct } from '../common.js';
 import { DefaultABITable } from '../defaultABITable.js';
-import { MoveNonStructTypes, MovePrimitive } from '../moveTypes.js';
+import {
+  MoveObject,
+  MoveOption,
+  MovePrimitive,
+  MovePrimitiveMap,
+} from '../moveTypes.js';
 import { ConvertStructFieldOptionType } from './structConvertor.js';
 
 /**
@@ -22,40 +27,10 @@ export type ConvertReturns<T extends readonly string[]> = T extends readonly [
  * Internal
  */
 type ConvertReturnType<TMoveType extends string> =
-  TMoveType extends MoveNonStructTypes
-    ? // it's a non-struct type
-      ConvertNonStructReturnType<TMoveType>
-    : // it's a struct type
-      UnknownStruct<TMoveType>;
-
-type ConvertPrimitiveReturnType<TMoveType extends MovePrimitive> =
-  TMoveType extends 'bool'
-    ? boolean
-    : TMoveType extends 'u8'
-      ? number
-      : TMoveType extends 'u16'
-        ? number
-        : TMoveType extends 'u32'
-          ? number
-          : TMoveType extends 'u64'
-            ? string
-            : TMoveType extends 'u128'
-              ? string
-              : TMoveType extends 'u256'
-                ? string
-                : TMoveType extends 'address'
-                  ? `0x${string}`
-                  : TMoveType extends '0x1::string::String'
-                    ? string
-                    : never;
-
-type ConvertNonStructReturnType<TMoveType extends MoveNonStructTypes> =
   TMoveType extends MovePrimitive
-    ? ConvertPrimitiveReturnType<TMoveType>
-    : TMoveType extends `vector<${infer TInner}>`
-      ? ConvertReturnType<TInner>[]
-      : TMoveType extends `0x1::object::Object<${string}>`
-        ? { inner: `0x${string}` }
-        : TMoveType extends `0x1::option::Option<${infer TInner}>`
-          ? ConvertStructFieldOptionType<DefaultABITable, TInner>
-          : UnknownStruct<TMoveType>;
+    ? MovePrimitiveMap<string>[TMoveType]
+    : TMoveType extends MoveObject
+      ? { inner: `0x${string}` }
+      : TMoveType extends MoveOption<infer TInner>
+        ? ConvertStructFieldOptionType<DefaultABITable, TInner>
+        : UnknownStruct<TMoveType>;

--- a/src/types/convertor/structConvertor.ts
+++ b/src/types/convertor/structConvertor.ts
@@ -7,7 +7,13 @@ import {
   ExtractStructType,
   ResourceStructName,
 } from '../extractor/structExtractor.js';
-import { MoveNonStructTypes, MovePrimitive } from '../moveTypes.js';
+import {
+  MoveNonStructTypes,
+  MoveObject,
+  MovePrimitive,
+  MovePrimitiveMap,
+  MoveVector,
+} from '../moveTypes.js';
 
 // Convert a struct field Move type to a TypeScript type
 export type ConvertStructFieldType<
@@ -19,38 +25,15 @@ export type ConvertStructFieldType<
   : // it's a struct type
     ConvertStructFieldStructType<TABITable, TMoveType>;
 
-/**
- * Internal
- */
-type ConvertPrimitiveStructField<T extends MovePrimitive> = T extends 'bool'
-  ? boolean
-  : T extends 'u8'
-    ? number
-    : T extends 'u16'
-      ? number
-      : T extends 'u32'
-        ? number
-        : T extends 'u64'
-          ? string
-          : T extends 'u128'
-            ? string
-            : T extends 'u256'
-              ? string
-              : T extends 'address'
-                ? `0x${string}`
-                : T extends '0x1::string::String'
-                  ? string
-                  : never;
-
 // Convert a struct field non-struct Move type to a TypeScript type
 type ConvertStructFieldNonStructType<
   TABITable extends ABITable,
   TMoveType extends MoveNonStructTypes,
 > = TMoveType extends MovePrimitive
-  ? ConvertPrimitiveStructField<TMoveType>
-  : TMoveType extends `vector<${infer TInner}>`
+  ? MovePrimitiveMap<string>[TMoveType]
+  : TMoveType extends MoveVector<infer TInner> // Custom Vector type
     ? ConvertStructFieldType<TABITable, TInner>[]
-    : TMoveType extends `0x1::object::Object<${string}>`
+    : TMoveType extends MoveObject
       ? { inner: `0x${string}` }
       : TMoveType extends `0x1::option::Option<${infer TInner}>`
         ? ConvertStructFieldOptionType<TABITable, TInner>

--- a/src/types/moveTypes.ts
+++ b/src/types/moveTypes.ts
@@ -2,25 +2,51 @@
  * Types from Move language
  */
 
+import { AnyNumber } from './common.js';
+
 export type MoveNonStructTypes =
   | MovePrimitive
   | MoveVector
   | MoveObject
   | MoveOption;
 
-export type MovePrimitive =
-  | 'bool'
-  | 'u8'
-  | 'u16'
-  | 'u32'
-  | 'u64'
-  | 'u128'
-  | 'u256'
-  | 'address'
-  | '0x1::string::String';
+/**
+ * All primitive simple types that are not complex, such as vector, object or struct
+ *
+ * @type {HighValue} - The type of high value number, in some cases can return just as string, or as AnyNumber, default as string
+ * @returns - A map of Move primitive types to their corresponding TypeScript types
+ */
+export type MovePrimitiveMap<HighValue extends AnyNumber | string = string> = {
+  bool: boolean;
 
-export type MoveVector = `vector<${string}>`;
+  address: `0x${string}`;
+  '0x1::string::String': string;
 
-export type MoveObject = `0x1::object::Object<${string}>`;
+  // Number
+  u8: number;
+  u16: number;
+  u32: number;
+  u64: HighValue;
+  u128: HighValue;
+  u256: HighValue;
 
-export type MoveOption = `0x1::option::Option<${string}>`;
+  'vector<bool>': boolean[];
+  'vector<u8>': string | number[] | Uint8Array;
+  'vector<u16>': number[];
+  'vector<u32>': number[];
+
+  'vector<u64>': HighValue[];
+  'vector<u128>': HighValue[];
+  'vector<u256>': HighValue[];
+  'vector<address>': `0x${string}`[];
+  'vector<string>': string[];
+  'vector<0x1::string::String>': string[];
+};
+
+export type MovePrimitive = keyof MovePrimitiveMap<AnyNumber | string>;
+
+export type MoveVector<I extends string = string> = `vector<${I}>`;
+
+export type MoveObject<I extends string = string> = `0x1::object::Object<${I}>`;
+
+export type MoveOption<I extends string = string> = `0x1::option::Option<${I}>`;


### PR DESCRIPTION
# This PR will: 

Refactor types aiming a new cleaner approach to make life easier when messing with abi type conversion.

# Motivation

At #237 I found myself dealing with a lot troubles having to manage a refactor in files that shouldn't be touched in the pr, because of that I am splitting those small tasks to it's own pr's like this one.

# Approaches explanation

I wanted to remove type conversions like this one that was being "recreated" in 3 files:
![image](https://github.com/user-attachments/assets/e83159d9-9bb4-4589-98da-3a598d38d049)

So I have created a map type for it that will provide type reusability and also easier type reading.
![image](https://github.com/user-attachments/assets/3da03a6b-f259-4195-9725-3e19133f6995)
But I had to make it generic with `HighValue` because I found that sometimes the api needs to use `string` instead of `AnyNumber`, so, instead of creating two separated types, you just need to provide the type in generics of the type of Number return you want to manage.

Example: 
```ts
type Uint64 = MovePrimitiveMap<string>["u64"] 
// string
```
 or 
```ts
type Uint64 = MovePrimitiveMap<AnyNumber>["u64"] 
// AnyNumber
```
