### PR TITLE
Bump aptos wallet adapter version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@aptos-labs/ts-sdk": "^1.35.0",
-    "@aptos-labs/wallet-adapter-react": "^3.7.11",
+    "@aptos-labs/wallet-adapter-react": "^6.0.0",
     "@changesets/cli": "^2.26.1",
     "@types/jest": "~29.5",
     "@types/node": "~18",
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "@aptos-labs/ts-sdk": "^1.35.0",
-    "@aptos-labs/wallet-adapter-react": "^3.7.11",
+    "@aptos-labs/wallet-adapter-react": "^6.0.0",
     "react": "^18.2.0",
     "@initia/react-wallet-widget": "^1.5.9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,14 +15,14 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aptos-connect/wallet-adapter-plugin@^2.3.2":
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/@aptos-connect/wallet-adapter-plugin/-/wallet-adapter-plugin-2.3.4.tgz#e7e3524bdde20cddaa7e1a4291826e43a89ec39f"
-  integrity sha512-YTV7pSpzv5tx97G5suMnDplMMQYDM0VfpP1hQjEn8jLkw6I+hNDxRfINL1/k3mp+jm0TmghmNUiFYHFuVSS6wg==
+"@aptos-connect/wallet-adapter-plugin@2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@aptos-connect/wallet-adapter-plugin/-/wallet-adapter-plugin-2.4.1.tgz#1f99d10a0205f4c1b681e5418b12ad5d759e453e"
+  integrity sha512-jFuOEtnNWvi8VjvrXrNFp4iI2dci8Jv0l1FIuC5khMZKj2sDHLNF1dbZtcXNTRbD32KDrzl0Lngi42K0gReX8Q==
   dependencies:
-    "@aptos-connect/wallet-api" "^0.1.6"
+    "@aptos-connect/wallet-api" "^0.1.9"
     "@identity-connect/crypto" "^0.2.5"
-    "@identity-connect/dapp-sdk" "^0.10.2"
+    "@identity-connect/dapp-sdk" "^0.10.4"
 
 "@aptos-connect/wallet-api@^0.1.6":
   version "0.1.7"
@@ -31,12 +31,28 @@
   dependencies:
     "@identity-connect/api" "^0.7.0"
 
-"@aptos-connect/web-transport@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@aptos-connect/web-transport/-/web-transport-0.1.2.tgz#1663aed00d65e120325eb0f9493a6321e9e1fe2a"
-  integrity sha512-PPSF1fJPoFxUG/iJSLUuh6cS6TZm7A5kZNqzvPVU1n9IKBKaUua9jqwEbqwILvSHnRIAPWzbP10t3zP5Wa17EQ==
+"@aptos-connect/wallet-api@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@aptos-connect/wallet-api/-/wallet-api-0.1.9.tgz#45fd74e11186c007c3e705c429cef2d3c2d88566"
+  integrity sha512-Olxvg/Jpf426uiEIUbxFuoRluhX3dja9EUqklY29yw/wOY7QDFv0+Es71xp8R2lgaU3gPFJxUwko1Jwz0XjswQ==
   dependencies:
-    "@aptos-connect/wallet-api" "^0.1.6"
+    "@aptos-labs/wallet-standard" "^0.3.0"
+    "@identity-connect/api" "^0.7.0"
+
+"@aptos-connect/wallet-api@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@aptos-connect/wallet-api/-/wallet-api-0.2.0.tgz#6636a10ceb186f5ba15979c2843b6c832b27571d"
+  integrity sha512-szCOoEfns7mGbBJHpfchQfN/hF2QVzS3tqLvmOfMXZ4s6eYJQZu9+NkTqIRxeNGIJKObYWKhHahRMmrA8f2Vsw==
+  dependencies:
+    "@aptos-labs/wallet-standard" "^0.3.0"
+    "@identity-connect/api" "^0.7.0"
+
+"@aptos-connect/web-transport@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@aptos-connect/web-transport/-/web-transport-0.2.0.tgz#22b32abc276bda592c1e45df769858795a46daf9"
+  integrity sha512-PzkXlJnUOuoXkBkOtuX4FHP2yiCZ/ySh0SpeA30XZxz+cOdYoxKWxRt82xPdTLCe0YmYl5SCG0Yh7DBL5lUvEg==
+  dependencies:
+    "@aptos-connect/wallet-api" "^0.2.0"
     uuid "^9.0.1"
 
 "@aptos-labs/aptos-cli@^0.1.2":
@@ -130,25 +146,26 @@
     eventemitter3 "^5.0.1"
     form-data "^4.0.0"
 
-"@aptos-labs/wallet-adapter-core@4.24.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-4.24.0.tgz#4b83af405587f1e00dffbba58f192a27abf1c792"
-  integrity sha512-Ve7kcUAO8vMh2QlxJ5oXk4dfhaBKQALR5y1oKWEFNxTd3BoMaYogHpIxSXa+4uSe2M+MsK0UEGfu7nvrqKMVZw==
+"@aptos-labs/wallet-adapter-core@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-5.4.1.tgz#3ef6b70a2db36cd034d19cc2a2f8213101f9e8c3"
+  integrity sha512-UR6p2DBf7QuA3ZT3D4nZHSvO80VtjUkl+fnMDj0ZW92V6C32GdKmya0UwgdLHB1RL43YKyPGyYBdVE2IAQaONg==
   dependencies:
-    "@aptos-connect/wallet-adapter-plugin" "^2.3.2"
-    "@aptos-labs/wallet-standard" "^0.2.0"
+    "@aptos-connect/wallet-adapter-plugin" "2.4.1"
+    "@aptos-labs/wallet-standard" "^0.3.0"
     "@atomrigslab/aptos-wallet-adapter" "^0.1.20"
     "@mizuwallet-sdk/aptos-wallet-adapter" "^0.3.2"
+    "@msafe/aptos-aip62-wallet" "^1.0.17"
     buffer "^6.0.3"
     eventemitter3 "^4.0.7"
     tweetnacl "^1.0.3"
 
-"@aptos-labs/wallet-adapter-react@^3.7.11":
-  version "3.7.11"
-  resolved "https://registry.yarnpkg.com/@aptos-labs/wallet-adapter-react/-/wallet-adapter-react-3.7.11.tgz#675ee8acd2ba4b6008f492e4d9d21804a5254335"
-  integrity sha512-ylENqv0E3rWmkEn8lzAHzjYdO2SqhCHbTnsM8X3Nq0T4yekzHCMuwuIWs9uF2iboeI7p7dUv6PmznDZQPCBUTg==
+"@aptos-labs/wallet-adapter-react@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@aptos-labs/wallet-adapter-react/-/wallet-adapter-react-6.0.0.tgz#8da8795cbe1b0124542122210a725f794d887939"
+  integrity sha512-/10lepGF1NNV6CW/sBBSdd8CC8BimHCZtkGIb9KuGRsugnYiLjYV7R8nNtUopxYGnxO/D+2+XipT1IVUfNHw7A==
   dependencies:
-    "@aptos-labs/wallet-adapter-core" "4.24.0"
+    "@aptos-labs/wallet-adapter-core" "5.4.1"
     "@radix-ui/react-slot" "^1.0.2"
 
 "@aptos-labs/wallet-standard@0.0.11":
@@ -164,10 +181,10 @@
   resolved "https://registry.yarnpkg.com/@aptos-labs/wallet-standard/-/wallet-standard-0.1.0-ms.1.tgz#3b6e218c22ceb463862fa6133fac0f424bf26389"
   integrity sha512-3aWEmdqMcll8D2lzhBZuYUW1o49TDpqw4QRAkHk00tSC3SwAkuukoW8g/M9lB5nHFxaX7UzuxeaYv8l6/mhJVQ==
 
-"@aptos-labs/wallet-standard@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@aptos-labs/wallet-standard/-/wallet-standard-0.2.0.tgz#d0f9d422d63ac93a02c2eb3157090434ded77379"
-  integrity sha512-4aoO4MlqzrW+CtO83MwbHMMtu91DL5B7YKRvhJbRnVB4R+QCOwBI/aQTkNZbKBDfOplLlqWTTl6Li0l6e02YLQ==
+"@aptos-labs/wallet-standard@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@aptos-labs/wallet-standard/-/wallet-standard-0.3.1.tgz#488d0f7270c16017f2a8f675a96d9f8c4d6b8e18"
+  integrity sha512-1cSmPxKB8R5HIlYPTKej7LzKflWbkod5t8peZ+OOHA3LbB1KI39qQn6gLid8kFBluvYsmkE1XEIIUyKLx07TsA==
 
 "@atomrigslab/aptos-wallet-adapter@^0.1.20":
   version "0.1.21"
@@ -747,6 +764,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@graphql-typed-document-node/core@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"
@@ -781,15 +803,25 @@
     ed2curve "^0.3.0"
     tweetnacl "^1.0.3"
 
-"@identity-connect/dapp-sdk@^0.10.2":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@identity-connect/dapp-sdk/-/dapp-sdk-0.10.3.tgz#60695ccc057f476a7f8e141d5e6bfc13310e8d82"
-  integrity sha512-EunHxy8emZEOurpANL/rrB7n5iALGStpkCL01ir6VPVB/Hj6GnEn0WXvXr7ZWTTYPQ/8w4FXUUHclRNSTRcg9A==
+"@identity-connect/crypto@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@identity-connect/crypto/-/crypto-0.2.6.tgz#c2e3277fe5b552f2fcec30c95dc27981fca89bc9"
+  integrity sha512-u+aj7uOlFNLtSVoWuIRDupTMBOo9y2s4l259tEouT2n0RvS2kp1Hl4RK+MIX9PQTdZDEnT2VddefymO6sz14Kw==
   dependencies:
-    "@aptos-connect/wallet-api" "^0.1.6"
-    "@aptos-connect/web-transport" "^0.1.2"
+    "@aptos-connect/wallet-api" "^0.2.0"
+    "@noble/hashes" "^1.3.1"
+    ed2curve "^0.3.0"
+    tweetnacl "^1.0.3"
+
+"@identity-connect/dapp-sdk@^0.10.4":
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/@identity-connect/dapp-sdk/-/dapp-sdk-0.10.5.tgz#e15454b1e3b0aa39368f19953f81cc85cfaef60b"
+  integrity sha512-2OTOIiOVnxW7ZvTbTHfsfkyTsWqmzHLz/l2cykHhvM3oOolBC9FGjiAkfW597V8UjN+Uqx2c0exI0ZGI5APjdw==
+  dependencies:
+    "@aptos-connect/wallet-api" "^0.2.0"
+    "@aptos-connect/web-transport" "^0.2.0"
     "@identity-connect/api" "^0.7.0"
-    "@identity-connect/crypto" "^0.2.5"
+    "@identity-connect/crypto" "^0.2.6"
     "@identity-connect/wallet-api" "^0.1.2"
     axios "^1.6.0"
     uuid "^9.0.1"
@@ -1198,6 +1230,11 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
   integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
 
+"@microsoft/fetch-event-source@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz#9ceecc94b49fbaa15666e38ae8587f64acce007d"
+  integrity sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==
+
 "@mizuwallet-sdk/aptos-wallet-adapter@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@mizuwallet-sdk/aptos-wallet-adapter/-/aptos-wallet-adapter-0.3.2.tgz#658a606c8b247ed5c5caac9b0c0740e02ca7281a"
@@ -1206,6 +1243,34 @@
     "@aptos-labs/ts-sdk" "^1.26.0"
     "@aptos-labs/wallet-standard" "0.1.0-ms.1"
     buffer "^6.0.3"
+
+"@mizuwallet-sdk/core@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@mizuwallet-sdk/core/-/core-1.4.0.tgz#a585f394569c00074d78052d93253f2c78a69d0c"
+  integrity sha512-03jKqKr+P4kCgcNQT2YNXmFBRVmeZ88vpEFKpQ9SaorCY4L9lF56kJS4Y+e/+A4Gb1bnqA7xuFmnEz13LjsZyg==
+  dependencies:
+    "@mizuwallet-sdk/protocol" "0.0.2"
+    buffer "^6.0.3"
+    jwt-decode "^4.0.0"
+
+"@mizuwallet-sdk/protocol@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@mizuwallet-sdk/protocol/-/protocol-0.0.2.tgz#1c139c2e5b442dc797c20bb743aeb2e1f5d00c07"
+  integrity sha512-AIrwaYKlmdG7lnipOlwW7sjlFJicm7v3fngQ3FEruAFc1Ydhg6gdMm4quEortWTziUxvSFo7V8JrRWF8C/FxDQ==
+  dependencies:
+    "@microsoft/fetch-event-source" "^2.0.1"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+
+"@msafe/aptos-aip62-wallet@^1.0.17":
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/@msafe/aptos-aip62-wallet/-/aptos-aip62-wallet-1.0.17.tgz#e336e3fb5206095de17cb0c53ebb758e023a964d"
+  integrity sha512-lqqFUr8ZiGl7tQzNIihHPAq26944O7MjMI4vDj17kgQCfkzwwuhQ/ai9/By3awpDZ2Sq3SZ2ppAbZkGYECrK+Q==
+  dependencies:
+    "@mizuwallet-sdk/core" "^1.4.0"
+    "@telegram-apps/bridge" "^1.9.1"
+    graphql "^16.10.0"
+    graphql-request "^7.1.2"
 
 "@mysten/bcs@^1.1.0":
   version "1.5.0"
@@ -1386,6 +1451,39 @@
   integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
   dependencies:
     defer-to-connect "^2.0.0"
+
+"@telegram-apps/bridge@^1.9.1":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@telegram-apps/bridge/-/bridge-1.9.2.tgz#5dbff521fbe3160ff6134fbb53fd3a8306306eb2"
+  integrity sha512-SJLcNWLXhbbZr9MiqFH/g2ceuitSJKMxUIZysK4zUNyTUNuonrQG80Q/yrO+XiNbKUj8WdDNM86NBARhuyyinQ==
+  dependencies:
+    "@telegram-apps/signals" "^1.1.1"
+    "@telegram-apps/toolkit" "^1.1.1"
+    "@telegram-apps/transformers" "^1.2.2"
+    "@telegram-apps/types" "^1.2.1"
+
+"@telegram-apps/signals@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@telegram-apps/signals/-/signals-1.1.1.tgz#807e7b73ba665126a5024dd4578e9aed52c06012"
+  integrity sha512-vz37r8lemGpPzDiBRfqpXYBynzmy3SFnY6zfHsTZABTYYt0b0WQZyU5mFDqqqugGhka78Gy11xmr9csgy4YgGA==
+
+"@telegram-apps/toolkit@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@telegram-apps/toolkit/-/toolkit-1.1.1.tgz#939c30f07dab7c3d754765b60021210cb9669b84"
+  integrity sha512-+vhKx6ngfvjyTE6Xagl3z1TPVbfx5s7xAkcYzCdHYUo6T60jLIqLgyZMcI1UPoIAMuMu1pHoO+p8QNCj/+tFmw==
+
+"@telegram-apps/transformers@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@telegram-apps/transformers/-/transformers-1.2.2.tgz#f995461b0f4dcfe54c6baed9a1abf4e21ca29339"
+  integrity sha512-vvMwXckd1D7Ozc0h66PSUwF5QLrRV9HlGJFFeBuUex8QEk5mSPtsJkLiqB8aBbwuFDa91+TUSM/CxqPZO/e9YQ==
+  dependencies:
+    "@telegram-apps/toolkit" "^1.1.1"
+    "@telegram-apps/types" "^1.2.1"
+
+"@telegram-apps/types@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@telegram-apps/types/-/types-1.2.1.tgz#e5886f65ec399c06838c257e96e2b130213c6d6c"
+  integrity sha512-so4HLh7clur0YyMthi9KVIgWoGpZdXlFOuQjk3+Q5NAvJZ11nAheBSwPlGw/Ko92+zwvrSBE/lQyN2+p17RP+w==
 
 "@types/babel__core@^7.1.14":
   version "7.20.1"
@@ -2953,6 +3051,18 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+graphql-request@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-7.1.2.tgz#52d7fd6d8d08c9f0b00c84a091376ce9fbdfa945"
+  integrity sha512-+XE3iuC55C2di5ZUrB4pjgwe+nIQBuXVIK9J98wrVwojzDW3GMdSBZfxUk8l4j9TieIpjpggclxhNEU9ebGF8w==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.2.0"
+
+graphql@^16.10.0:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.11.0.tgz#96d17f66370678027fdf59b2d4c20b4efaa8a633"
+  integrity sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -4613,16 +4723,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4663,14 +4764,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4824,6 +4918,11 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
+tweetnacl-util@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
+  integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
+
 tweetnacl@1.x.x, tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
@@ -4963,16 +5062,7 @@ wif@^5.0.0:
   dependencies:
     bs58check "^4.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
The package uses a very old wallet-adapter version which causes the build of dapps using this package with an upgraded adapter version to fail.

Updating Surf to use the latest adapter version.

Note: was trying to bump the aptos-ts-sdk version as well, but that causes tests to fail. 